### PR TITLE
Circular references

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A utility for returning deeply nested key-values as tuples of varying length.
 
 ### observations
 
--   ignores circular references
+-   `deepEntries` & `deepEntriesIterator` ignore circular references
 -   instances of `Set` will be converted to arrays
 -   instances of `Map` will yield `Map.prototype.entries()`  
     (limited support / usefulness TBD)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A utility for returning deeply nested key-values as tuples of varying length.
 
 ### observations
 
+-   ignores circular references
 -   instances of `Set` will be converted to arrays
 -   instances of `Map` will yield `Map.prototype.entries()`  
     (limited support / usefulness TBD)

--- a/src/deep-entries-iterator.js
+++ b/src/deep-entries-iterator.js
@@ -1,16 +1,30 @@
 import { identity } from './utils'
 import { entriesIterator } from './entries-iterator'
 
-export function* deepEntriesIterator(input, mapFn) {
+function* deepEntriesIterator_(input, mapFn, parentCircularSet) {
 	const map = typeof mapFn === 'function' ? mapFn : identity
 	for (let [key, value] of entriesIterator(input)) {
 		if (typeof value !== 'object') {
 			const entry = map([key, value])
 			if (entry !== undefined) yield entry
-		} else
-			for (let entries of deepEntriesIterator(value)) {
-				const entry = map([key, ...entries])
-				if (entry !== undefined) yield entry
+		} else {
+			const circularSet = parentCircularSet || new WeakSet()
+			circularSet.add(input)
+
+			if (!circularSet.has(value)) {
+				for (let entries of deepEntriesIterator_(
+					value,
+					undefined,
+					circularSet
+				)) {
+					const entry = map([key, ...entries])
+					if (entry !== undefined) yield entry
+				}
 			}
+		}
 	}
+}
+
+export function* deepEntriesIterator(input, mapFn) {
+	yield* deepEntriesIterator_(input, mapFn)
 }

--- a/src/entries-iterator.js
+++ b/src/entries-iterator.js
@@ -12,8 +12,11 @@ export function* entriesIterator(input) {
 			break
 
 		case '[object Object]':
-			for (let key in input)
-				if (input.hasOwnProperty(key)) yield [key, input[key]]
+		default:
+			if (typeof input === 'object')
+				for (let key in input)
+					if (Object.prototype.hasOwnProperty.call(input, key))
+						yield [key, input[key]]
 			break
 	}
 }

--- a/test/deep-entries.test.js
+++ b/test/deep-entries.test.js
@@ -253,4 +253,62 @@ describe('deepEntries', () => {
 		)
 		expect(actual).toEqual(expected)
 	})
+
+	describe('circular references', () => {
+		it('should ignore references', () => {
+			const input = { a: 1 }
+			input.b = input
+
+			const expected = [['a', 1]]
+			const actual = deepEntries(input)
+
+			expect(actual).toEqual(expected)
+		})
+
+		it('should ignore deeply nested references', () => {
+			const input = { a: 1, b: { c: 1 } }
+			input.b.ref = input
+
+			const expected = [['a', 1], ['b', 'c', 1]]
+			const actual = deepEntries(input)
+
+			expect(actual).toEqual(expected)
+		})
+
+		it('should ignore deep-referenced references', () => {
+			const input = { a: 1, b: { c: { d: 1 } } }
+			input.b.c.ref = input.b
+
+			const expected = [['a', 1], ['b', 'c', 'd', 1]]
+			const actual = deepEntries(input)
+
+			expect(actual).toEqual(expected)
+		})
+
+		it('should handle crossed references', () => {
+			const input = { a: { b: 1 }, c: { d: 2 } }
+			input.a.e = input.c
+			input.c.f = input.a
+
+			const expected = [
+				['a', 'b', 1],
+				['a', 'e', 'd', 2],
+				['c', 'd', 2],
+				['c', 'f', 'b', 1]
+			]
+			const actual = deepEntries(input)
+
+			expect(actual).toEqual(expected)
+		})
+
+		it('should handle sibling references', () => {
+			const input = { a: [{ b: 1 }] }
+			input.a.push(input.a[0])
+
+			const expected = [['a', 0, 'b', 1], ['a', 1, 'b', 1]]
+			const actual = deepEntries(input)
+
+			expect(actual).toEqual(expected)
+		})
+	})
 })


### PR DESCRIPTION
 - Entries where the value is a circular reference (_i.e._ a parent of a given tree),
 are omitted from the result set. 
 - Iterator is more permissive towards custom object type / string tags. 