### PR TITLE
Better handling of builtin and primitive-like types

### DIFF
--- a/src/deep-entries-iterator.js
+++ b/src/deep-entries-iterator.js
@@ -1,10 +1,10 @@
-import { identity } from './utils'
+import { identity, isObjectLike } from './utils'
 import { entriesIterator } from './entries-iterator'
 
 function* deepEntriesIterator_(input, mapFn, parentCircularSet) {
 	const map = typeof mapFn === 'function' ? mapFn : identity
 	for (let [key, value] of entriesIterator(input)) {
-		if (typeof value !== 'object') {
+		if (!isObjectLike(value)) {
 			const entry = map([key, value])
 			if (entry !== undefined) yield entry
 		} else {

--- a/src/entries-iterator.js
+++ b/src/entries-iterator.js
@@ -4,7 +4,7 @@ export function* entriesIterator(input) {
 	switch (getInterface(input)) {
 		case 'Array':
 		case 'Map':
-		case 'URLSearchParam':
+		case 'URLSearchParams':
 			yield* input.entries()
 			break
 

--- a/src/entries-iterator.js
+++ b/src/entries-iterator.js
@@ -1,19 +1,31 @@
-import { isObjectLike } from './utils'
+import { getInterface, isObjectLike } from './utils'
 
 export function* entriesIterator(input) {
-	switch (Object.prototype.toString.call(input)) {
-		case '[object Array]':
-		case '[object Map]':
-		case '[object URLSearchParams]':
+	switch (getInterface(input)) {
+		case 'Array':
+		case 'Map':
+		case 'URLSearchParam':
 			yield* input.entries()
 			break
 
-		case '[object Set]':
+		case 'Set':
+		case 'NodeList':
+		case 'Int8Array':
+		case 'Uint8Array':
+		case 'Uint8ClampedArray':
+		case 'Int16Array':
+		case 'Uint16Array':
+		case 'Int32Array':
+		case 'Uint32Array':
+		case 'Float32Array':
+		case 'Float64Array':
+		case 'BigInt64Array':
+		case 'BigUint64Array':
 			let i = 0
 			for (let value of input) yield [i++, value]
 			break
 
-		case '[object Object]':
+		case 'Object':
 		default:
 			if (isObjectLike(input))
 				for (let key in input)

--- a/src/entries-iterator.js
+++ b/src/entries-iterator.js
@@ -1,3 +1,5 @@
+import { isObjectLike } from './utils'
+
 export function* entriesIterator(input) {
 	switch (Object.prototype.toString.call(input)) {
 		case '[object Array]':
@@ -13,7 +15,7 @@ export function* entriesIterator(input) {
 
 		case '[object Object]':
 		default:
-			if (typeof input === 'object')
+			if (isObjectLike(input))
 				for (let key in input)
 					if (Object.prototype.hasOwnProperty.call(input, key))
 						yield [key, input[key]]

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,6 +16,10 @@ export const isObjectLike = x => {
 			return false
 
 		default:
+			if (x === null) {
+				return false
+			}
+
 			if (tag.startsWith('HTML')) {
 				return false
 			}

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,8 @@ export const getInterface = x => {
 }
 
 export const isObjectLike = x => {
-	switch (getInterface(x)) {
+	const tag = getInterface(x)
+	switch (tag) {
 		case 'String':
 		case 'Number':
 		case 'Boolean':
@@ -15,6 +16,10 @@ export const isObjectLike = x => {
 			return false
 
 		default:
+			if (tag.startsWith('HTML')) {
+				return false
+			}
+
 			return typeof x === 'object'
 	}
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,1 +1,15 @@
 export const identity = x => x
+
+export const isObjectLike = x => {
+	switch (Object.prototype.toString.call(x)) {
+		case '[object String]':
+		case '[object Number]':
+		case '[object Boolean]':
+		case '[object RegExp]':
+		case '[object Date]':
+			return false
+
+		default:
+			return typeof x === 'object'
+	}
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,12 +1,17 @@
 export const identity = x => x
 
+export const getInterface = x => {
+	const str = Object.prototype.toString.call(x)
+	return str.substring(8, str.length - 1) // [object ...]
+}
+
 export const isObjectLike = x => {
-	switch (Object.prototype.toString.call(x)) {
-		case '[object String]':
-		case '[object Number]':
-		case '[object Boolean]':
-		case '[object RegExp]':
-		case '[object Date]':
+	switch (getInterface(x)) {
+		case 'String':
+		case 'Number':
+		case 'Boolean':
+		case 'RegExp':
+		case 'Date':
 			return false
 
 		default:

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@ export const identity = x => x
 
 export const getInterface = x => {
 	const str = Object.prototype.toString.call(x)
-	return str.substring(8, str.length - 1) // [object ...]
+	return str.substring(8, str.length - 1)
 }
 
 export const isObjectLike = x => {

--- a/test/deep-entries-iterator.test.js
+++ b/test/deep-entries-iterator.test.js
@@ -177,6 +177,32 @@ describe('deepEntriesIterator', () => {
 		})
 	})
 
+	describe('array-like members', () => {
+		describe('should consistently index typed-arrays by number', () => {
+			;[
+				Int8Array,
+				Uint8Array,
+				Uint8ClampedArray,
+				Int16Array,
+				Uint16Array,
+				Int32Array,
+				Uint32Array,
+				Float32Array,
+				Float64Array,
+				BigInt64Array,
+				BigUint64Array
+			].forEach(I =>
+				it(I.name, () => {
+					const n = I.name.startsWith('Big') ? 0n : 0
+					const input = I.from([n])
+					const expected = [[0, n]]
+					const actual = Array.from(deepEntriesIterator(input))
+					expect(actual).toEqual(expected)
+				})
+			)
+		})
+	})
+
 	describe('input type Map', () => {
 		it('should return entries, ignoring object members', () => {
 			const input = Object.assign(

--- a/test/deep-entries-iterator.test.js
+++ b/test/deep-entries-iterator.test.js
@@ -260,6 +260,29 @@ describe('deepEntriesIterator', () => {
 		})
 	})
 
+	describe('input type URLSearchParams', () => {
+		it('should return entries, ignoring object members', () => {
+			const input = Object.assign(new URLSearchParams({ foo: true }), {
+				bar: true
+			})
+			const expected = [['foo', 'true']]
+			const actual = Array.from(deepEntriesIterator(input))
+			expect(actual).toEqual(expected)
+		})
+
+		it('should return deep nested entries', () => {
+			const input = {
+				value: new URLSearchParams({ foo: true, bar: false })
+			}
+			const expected = [
+				['value', 'foo', 'true'],
+				['value', 'bar', 'false']
+			]
+			const actual = Array.from(deepEntriesIterator(input))
+			expect(actual).toEqual(expected)
+		})
+	})
+
 	describe('input type Set', () => {
 		it('should return entries, ignoring object members', () => {
 			const input = Object.assign(

--- a/test/deep-entries-iterator.test.js
+++ b/test/deep-entries-iterator.test.js
@@ -357,6 +357,53 @@ describe('deepEntriesIterator', () => {
 		})
 	})
 
+	describe('DOM elements', () => {
+		const mockElement = tagName => {
+			class MockElement {
+				get [Symbol.toStringTag]() {
+					return tagName
+				}
+			}
+			return new MockElement()
+		}
+
+		const mockNodeList = (...els) => {
+			class MockNodeList {
+				*[Symbol.iterator]() {
+					yield* els
+				}
+				get [Symbol.toStringTag]() {
+					return 'NodeList'
+				}
+			}
+			return new MockNodeList()
+		}
+
+		describe('it should return empty, ignoring object members', () => {
+			;['HTMLElement', 'HTMLImageElement', 'HTMLAnchorElement'].forEach(
+				el =>
+					it(el, () => {
+						const input = Object.assign(mockElement(el), {
+							foo: true
+						})
+						const expected = []
+						const actual = Array.from(deepEntriesIterator(input))
+						expect(actual).toEqual(expected)
+					})
+			)
+		})
+
+		describe('it should return deep nested entries', () => {
+			const el1 = mockElement('HTMLElement')
+			const el2 = mockElement('HTMLImageElement')
+			const el3 = mockElement('HTMLAnchorElement')
+			const input = mockNodeList(el1, el2, el3)
+			const expected = [[0, el1], [1, el2], [2, el3]]
+			const actual = Array.from(deepEntriesIterator(input))
+			expect(actual).toEqual(expected)
+		})
+	})
+
 	describe('should optionally apply a transform function', () => {
 		const input = {
 			a: 0,

--- a/test/deep-entries-iterator.test.js
+++ b/test/deep-entries-iterator.test.js
@@ -213,7 +213,7 @@ describe('deepEntriesIterator', () => {
 	})
 
 	describe('input type Set', () => {
-		it('should return entries, ignore object members', () => {
+		it('should return entries, ignoring object members', () => {
 			const input = Object.assign(
 				new Set([
 					1, //
@@ -259,6 +259,72 @@ describe('deepEntriesIterator', () => {
 				['value', 3, '3', 2],
 				['value', 4, 0, '4', 0],
 				['value', 4, 0, '5', 0]
+			]
+			const actual = Array.from(deepEntriesIterator(input))
+			expect(actual).toEqual(expected)
+		})
+	})
+
+	describe('not-normally-enumerated builtin object', () => {
+		describe('it should return empty, ignoring object members', () => {
+			it('when regex', () => {
+				const input = Object.assign(/foo/, {
+					bar: true
+				})
+				const expected = []
+				const actual = Array.from(deepEntriesIterator(input))
+				expect(actual).toEqual(expected)
+			})
+
+			it('when date', () => {
+				const input = Object.assign(new Date(), {
+					bar: true
+				})
+				const expected = []
+				const actual = Array.from(deepEntriesIterator(input))
+				expect(actual).toEqual(expected)
+			})
+
+			it('when boxed number', () => {
+				const input = Object.assign(new Number(1), {
+					bar: true
+				})
+				const expected = []
+				const actual = Array.from(deepEntriesIterator(input))
+				expect(actual).toEqual(expected)
+			})
+
+			it('when boxed boolean', () => {
+				const input = Object.assign(new Boolean(true), {
+					bar: true
+				})
+				const expected = []
+				const actual = Array.from(deepEntriesIterator(input))
+				expect(actual).toEqual(expected)
+			})
+
+			it('when boxed string (builtin iterator)', () => {
+				const input = new String('foo')
+				const expected = []
+				const actual = Array.from(deepEntriesIterator(input))
+				expect(actual).toEqual(expected)
+			})
+		})
+
+		it('should return deep nested entries', () => {
+			const input = {
+				regex: /foo/,
+				date: new Date(),
+				boxedNumber: new Number(1),
+				boxedBoolean: new Boolean(true),
+				boxedString: new String('foo')
+			}
+			const expected = [
+				['regex', input.regex],
+				['date', input.date],
+				['boxedNumber', input.boxedNumber],
+				['boxedBoolean', input.boxedBoolean],
+				['boxedString', input.boxedString]
 			]
 			const actual = Array.from(deepEntriesIterator(input))
 			expect(actual).toEqual(expected)

--- a/test/deep-entries-iterator.test.js
+++ b/test/deep-entries-iterator.test.js
@@ -48,6 +48,28 @@ describe('deepEntriesIterator', () => {
 		)
 	})
 
+	describe('deep nested "empty" input', () => {
+		it('should return null entries', () => {
+			const input = [null, [null]]
+			const expected = [
+				[0, null], //
+				[1, 0, null]
+			]
+			const actual = Array.from(deepEntriesIterator(input))
+			expect(actual).toEqual(expected)
+		})
+
+		it('should return undefined entries', () => {
+			const input = [undefined, [undefined]]
+			const expected = [
+				[0, undefined], //
+				[1, 0, undefined]
+			]
+			const actual = Array.from(deepEntriesIterator(input))
+			expect(actual).toEqual(expected)
+		})
+	})
+
 	describe('should return an iterator that honours insertion order', () => {
 		const input = {
 			a: 1,


### PR DESCRIPTION
Fixes some inconsistencies and changes the handling of some builtin object-types for convenience - as I'd only previously used the util for data-wrangling JSON, I hadn't considered them.

## Primitive-like types

Instances of `RegExp`, `Date`, `HTMLElement` and boxed primitives will be treated as atomic values - where technically `typeof ? === 'object'` they can have own-members, practically they are not typically enumerated over.

_.e.g. where previously: 

```js
deepEntries([  /foo/, new Date(0), new String('foo') ])
// would yield: [ [ 2, '0', 'f' ], [ 2, '1', 'o' ], [ 2, '2', 'o' ] ]
```

deep-entries now returns something more useful:

```js
[
    [ 0, /foo/ ],
    [ 1, 1970-01-01T00:00:00.000Z ],
    [ 2, [String: 'foo'] ] 
]
```

> _This update should cover most usages but is not exhaustive.  I considered including `Promise` but it needs a little more thought - could maybe expose some additional async handling._

## Fixes

 - Typed-arrays such as `Int8Array` are now indexed by type `number` to be consistent with regular arrays (previously they would be treated as objects and keys coerced to `string`).
 - As `typeof null === 'object'` it was yielding an empty entry instead of being treated as a value itself - it should be up to the consumer to decided what data to keep. 