### PR TITLE
Basic Types and Support for Deno Import

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
 		"prebuild": "rimraf dist",
 		"build": "rollup -c",
 		"test": "jest -c jest.config.json",
-		"prerelease": "npm run build && npm run test",
+		"test-deno": "deno test ./test/_deno.js",
+		"prerelease": "npm run build && npm run test && npm run test-deno",
 		"release": "standard-version --commit-all"
 	},
 	"husky": {

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
 		"deepentry"
 	],
 	"files": [
-		"dist/"
+		"dist/",
+		"types.d.ts"
 	],
 	"main": "dist/index.cjs.js",
 	"module": "dist/index.esm.js",
+	"types": "types.d.ts",
 	"scripts": {
 		"prebuild": "rimraf dist",
 		"build": "rollup -c",
@@ -38,7 +40,7 @@
 		}
 	},
 	"lint-staged": {
-		"**/*.{js,json,md}": [
+		"**/*.{ts,js,json,md}": [
 			"prettier --write",
 			"git add"
 		]

--- a/src/deep-entries-iterator.js
+++ b/src/deep-entries-iterator.js
@@ -1,5 +1,5 @@
-import { identity, isObjectLike } from './utils'
-import { entriesIterator } from './entries-iterator'
+import { identity, isObjectLike } from './utils.js'
+import { entriesIterator } from './entries-iterator.js'
 
 function* deepEntriesIterator_(input, mapFn, parentCircularSet) {
 	const map = typeof mapFn === 'function' ? mapFn : identity

--- a/src/deep-entries.js
+++ b/src/deep-entries.js
@@ -1,4 +1,4 @@
-import { deepEntriesIterator } from './deep-entries-iterator'
+import { deepEntriesIterator } from './deep-entries-iterator.js'
 
 export const deepEntries = (input, mapFn) =>
 	Array.from(deepEntriesIterator(input, mapFn))

--- a/src/delimit-entry.js
+++ b/src/delimit-entry.js
@@ -1,4 +1,4 @@
-import { rotateEntry } from './rotate-entry'
+import { rotateEntry } from './rotate-entry.js'
 
 export const delimitEntryBy = delimiter => entry => {
 	if (entry === undefined) return

--- a/src/entries-iterator.js
+++ b/src/entries-iterator.js
@@ -1,4 +1,4 @@
-import { getInterface, isObjectLike } from './utils'
+import { getInterface, isObjectLike } from './utils.js'
 
 export function* entriesIterator(input) {
 	switch (getInterface(input)) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
-export { deepEntries } from './deep-entries'
-export { deepEntriesIterator } from './deep-entries-iterator'
-export { delimitEntry, delimitEntryBy } from './delimit-entry'
-export { rotateEntry, rotateEntryBy } from './rotate-entry'
+/// <reference types="../types.d.ts" />
+
+export { deepEntries } from './deep-entries.js'
+export { deepEntriesIterator } from './deep-entries-iterator.js'
+export { delimitEntry, delimitEntryBy } from './delimit-entry.js'
+export { rotateEntry, rotateEntryBy } from './rotate-entry.js'

--- a/test/_deno.js
+++ b/test/_deno.js
@@ -1,0 +1,35 @@
+import { assert, assertEquals } from 'https://deno.land/std/testing/asserts.ts'
+
+import {
+	deepEntries,
+	deepEntriesIterator,
+	delimitEntry,
+	delimitEntryBy,
+	rotateEntry,
+	rotateEntryBy
+} from '../src/index.js'
+
+Deno.test('all imports have extensions', () => {
+	// listed in case of "unused import" linting
+	// and / or unintended dead-code elimination
+	deepEntries
+	deepEntriesIterator
+	delimitEntry
+	delimitEntryBy
+	rotateEntry
+	rotateEntryBy
+
+	assert(true)
+})
+
+Deno.test('basic input / output', () => {
+	const input = [1, [2, [3]]]
+	const expected = [
+		[0, 1], //
+		[1, 0, 2], //
+		[1, 1, 0, 3]
+	]
+	const actual = deepEntries(input)
+
+	assertEquals(actual, expected)
+})

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,23 @@
+export type DeepEntry = [unknown, unknown, ...unknown[]]
+
+export declare function deepEntriesIterator<T = DeepEntry>(
+	input: unknown,
+	mapFn?: (entry: DeepEntry) => T
+): IterableIterator<T>
+
+export declare function deepEntries<T = DeepEntry>(
+	input: unknown,
+	mapFn?: (entry: DeepEntry) => T
+): T[]
+
+export declare function rotateEntry(entry: DeepEntry): DeepEntry
+
+export declare function rotateEntryBy(
+	n: number
+): (entry: DeepEntry) => DeepEntry
+
+export declare function delimitEntry<T = unknown>(entry: DeepEntry): [string, T]
+
+export declare function delimitEntryBy<T = unknown>(
+	delimiter: string
+): (entry: DeepEntry) => [string, T]


### PR DESCRIPTION
Add minimal typedef - doesn't conserve input types but should be okay for now since the primary use for this util is data-wrangling anyway - would of alternatively liked to have been able to express the following but it seems that variadic tuple types are a PITA and I've already spent too long in that rabbit hole...

```typescript
type DeepEntry<T> = {
    [K in keyof T]:
    T[K] extends object
    ? [K, ...DeepEntry<T[K]>]
    : [K, T[K]]
}[keyof T]
```
